### PR TITLE
Added CSS styling for material icons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -183,9 +183,31 @@ body {
   #MATERIAL ICON
 \*-----------------------------------*/
 
+@font-face {
+  font-family: 'Material Symbol Rounded';
+  font-style: normal;
+  font-weight: 400;
+  src: url(/assets/font/material-symbol-rounded.woff2) format('woff2');
+}
 
-
-
+.m-icon {
+  font-family: 'Material Symbol Rounded';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 2.4rem;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  font-feature-settings: "liga";
+  -webkit-font-feature-settings: "liga";
+  -webkit-font-smoothing: antialiased;
+  height: 1em;
+  width: 1em;
+  overflow: hidden;
+}
 
 /*-----------------------------------*\
   #REUSED STYLE


### PR DESCRIPTION
# Weather App Project Pull Request

## Description
This pull request documents the addition of custom font icon support for Material icons in the Forecast Finesse weather app project. The changes include the inclusion of the Material Symbol Rounded font and the styles for using these icons.

## Changes Made

### Custom Material Icon Font
- Added a custom font face called 'Material Symbol Rounded' to support Material icons.
- The font is provided in the WOFF2 format and is loaded from the `/assets/font/` directory.
- The font-family, font-style, and font-weight are specified for correct usage.

### Material Icon Styles
- Created a CSS class `.m-icon` for applying Material icons.
- Set the `font-family` to 'Material Symbol Rounded' to use the custom font.
- Adjusted the `font-size`, `line-height`, `letter-spacing`, and other text-related properties to ensure proper icon rendering.
- Made sure the icons do not wrap to the next line with `white-space` and `word-wrap`.
- Set `direction` to left-to-right ('ltr') and configured font feature settings for ligatures and font smoothing for enhanced rendering.

### Icon Sizing and Overflow
- The icons are sized to be 1em by 1em and hidden overflow is enabled to maintain proper sizing.

## Checklist
- [x] Added custom Material icon font.
- [x] Defined styles for Material icons using the `.m-icon` class.

Thanks!