### PR TITLE
Added styling to current weather card of html

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -543,10 +543,40 @@ article.container::before {
   #CURRENT WEATHER
 \*-----------------------------------*/
 
+.current-weather-card .weapper {
+  margin-block: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
 
+.current-weather-card .weather-icon {
+  margin-inline: auto;
+}
 
+.current-weather-card > .body-3 {
+  text-transform: capitalize;
+}
 
+.current-weather-card .meta-list {
+  margin-block-start: 16px;
+  padding-block-start: 16px;
+  border-block-start: 1px solid var(--outline);
+}
 
+.current-weather-card .meta-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.current-weather-card .meta-item:not(:last-child) {
+  margin-block-end: 12px;
+}
+
+.current-weather-card .meta-text {
+  color: var(--on-surface-variant);
+}
 
 /*-----------------------------------*\
   #HIGHLIGHTS

--- a/index.html
+++ b/index.html
@@ -71,26 +71,25 @@
         <article class="container">
             <div class="content-left">
                 <!-- Current weather section -->
-                <section class="section current-weather" aria-label="current weather" data-current-weather>
-                  <div class="card card-lg current-weather-card">
-                    <h2 class="title-2 card-title">Now</h2>
-                    <div class="weapper">
-                        <p class="heading">25&deg;<sup>c</sup></p>
-                        <img src="./assets/images/weather_icons/01d.png" width="64" height="64" 
-                        alt="Overcast Clouds" class="weather-icon">
+                <section class="section current-weather" aria-label="Current Weather" data-current-weather>
+                    <div class="card card-lg current-weather-card">
+                        <h2 class="title-2 card-title">Now</h2>
+                        <div class="wrapper">
+                            <p class="heading">25&deg;<sup>c</sup></p>
+                            <img src="./assets/images/weather_icons/01d.png" width="64" height="64" alt="Overcast Clouds" class="weather-icon">
+                        </div>
+                        <p class="body-3">Overcast Clouds</p>
+                        <ul class="meta-list">
+                            <li class="meta-item">
+                                <span class="m-icon">calendar_today</span>
+                                <p class="title-3 meta-text">Sunday 15, Oct</p>
+                            </li>
+                            <li class="meta-item">
+                                <span class="m-icon">location_on</span>
+                                <p class="title-3 meta-text">Melbourne, Victoria</p>
+                            </li>
+                        </ul>
                     </div>
-                    <p class="body-3">Overcast Clouds</p>
-                    <ul class="meta-list">
-                        <li class="meta-list">
-                           <span class="m-icon">calendar_today</span> 
-                           <p class="title-3 meta-text">Sunday 15, Oct</p>
-                        </li>
-                        <li class="meta-list">
-                            <span class="m-icon">location_on</span> 
-                            <p class="title-3 meta-text">Melbourne, Vicotria</p>
-                        </li>
-                    </ul>
-                  </div> 
                 </section>
             </div>
         </article>


### PR DESCRIPTION
## Updates to the Current Weather Section

In this pull request, I've made several CSS updates to enhance the styling and layout of the "Current Weather" section of your weather app. Let's explore these changes in detail:

### `.current-weather-card .weapper`

```
.current-weather-card .weapper {
  margin-block: 12px;
  display: flex;
  gap: 8px;
  align-items: center;
}
```

- The `.weapper` element is a part of the "Current Weather" card.
- I've added `margin-block` to create spacing above and below the `.weapper`.
- The use of `display: flex` and `align-items: center` ensures that the content inside `.weapper` is horizontally centered and evenly spaced.

### `.current-weather-card .weather-icon`

```
.current-weather-card .weather-icon {
  margin-inline: auto;
}
```

#### This rule targets the weather icon inside the "Current Weather" card:

- margin-inline: auto centers the weather icon within the card.

### .current-weather-card > .body-3

```
.current-weather-card > .body-3 {
  text-transform: capitalize;
}
```

- The `.body-3` text within the "Current Weather" card is modified.
- `text-transform: capitalize` capitalizes the text, ensuring consistent text formatting.

### .current-weather-card .meta-list

```
.current-weather-card .meta-list {
  margin-block-start: 16px;
  padding-block-start: 16px;
  border-block-start: 1px solid var(--outline);
}
```

#### This rule enhances the styling of the meta information list:

- `margin-block-start` and `padding-block-start` create space above the meta-list, and `border-block-start` adds a separator line below the meta-list.

### .current-weather-card .meta-item

```
.current-weather-card .meta-item {
  display: flex;
  align-items: center;
  gap: 8px;
}
```

- The `.meta-item` elements inside the meta-list are updated.
- `display: flex` and `align-items: center` align the content horizontally and center it vertically within each meta-item.
- A `gap` of `8px` provides spacing between elements.

###  .current-weather-card .meta-item:not(:last-child)

```
.current-weather-card .meta-item:not(:last-child) {
  margin-block-end: 12px;
}
```

#### This rule creates vertical spacing between meta-items:

- `margin-block-end` adds spacing below each meta-item, except for the last one.

### .current-weather-card .meta-text

```
.current-weather-card .meta-text {
  color: var(--on-surface-variant);
}
```

- The text color of the meta-text within the "Current Weather" card is updated.
- `color: var(--on-surface-variant)` applies a consistent color style.

These CSS updates enhance the presentation of the "Current Weather" section, ensuring better alignment, spacing, and text formatting. This contributes to an improved user experience. 

Feel free to review these changes and provide any feedback or suggestions.

Thanks!