### PR TITLE
Added css styling for 5 day forecast section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -582,9 +582,32 @@ article.container::before {
   #HIGHLIGHTS
 \*-----------------------------------*/
 
+.forecast-card .title-2 {
+  margin-block-end: 0;
+}
 
+.forecast-card :is(.card-item, .icon-wrapper) {
+  display: flex;
+  align-items: center;
+}
 
+.forecast-card .card-item:not(:last-child) {
+  margin-block-end: 12px;
+}
 
+.forecast-card .icon-wrapper {
+  gap: 8px;
+}
+
+.forecast-card .label-1 {
+  color: var(--on-surface-variant);
+  font-weight: var(--weight-semiBold);
+}
+
+.forecast-card .card-item > .label-1 {
+  width: 100%;
+  text-align: right;
+}
 
 /*-----------------------------------*\
   #HOURLY FORECAST


### PR DESCRIPTION
## CSS Styling for the 5 Day Forecast Section

In this pull request, I've applied CSS styling to the "5 Day Forecast" section of the weather app to enhance its visual appeal and user-friendliness.

### CSS Updates

I've added the following CSS rules to style the "5 Day Forecast" section:

```css
.forecast-card .title-2 {
  margin-block-end: 0;
}

.forecast-card :is(.card-item, .icon-wrapper) {
  display: flex;
  align-items: center;
}

.forecast-card .card-item:not(:last-child) {
  margin-block-end: 12px;
}

.forecast-card .icon-wrapper {
  gap: 8px;
}

.forecast-card .label-1 {
  color: var(--on-surface-variant);
  font-weight: var(--weight-semiBold);
}

.forecast-card .card-item > .label-1 {
  width: 100%;
  text-align: right;
}
```

These CSS rules are designed to:

- Remove excessive margin below the section title.
- Ensure that forecast items are displayed in a flex layout and vertically aligned in the center.
- Add spacing between forecast items for better readability.
- Provide the necessary spacing and alignment for the weather icon and temperature.
- Style the date and day labels with the specified font color and font weight.
- Make sure the date and day labels span the entire width with right-aligned text.

These changes should improve the visual consistency and readability of the "5 Day Forecast" section.

Thanks!