### PR TITLE
Added css to hourly forecast section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -709,7 +709,43 @@ article.container::before {
   #HOURLY FORECAST
 \*-----------------------------------*/
 
+.slider-container {
+  overflow-x: auto;
+  margin-inline: -16px;
+}
 
+.slider-container::-webkit-scrollbar {
+  display: none;
+}
+
+.slider-list {
+  display: flex;
+  gap: 12px;
+}
+
+.slider-list:first-child {
+  margin-block-end: 16px;
+}
+
+.slider-list::before,
+.slider-list::after {
+  content: "";
+  min-width: 4px;
+}
+
+.slider-item {
+  min-width: 110px;
+  flex: 1 1 100%;
+}
+
+.slider-card {
+  text-align: center;
+}
+
+.slider-item .weather-icon {
+  margin-inline: auto;
+  margin-block: 12px;
+}
 
 
 

--- a/index.html
+++ b/index.html
@@ -240,7 +240,8 @@
                   </div>  
                 </section>
                 <!-- Hourly forecast -->
-                <div class="section hourly-forecast" aria-label="hourly forecast" data-hourly-forecast>
+                <div class="section hourly-forecast" aria-label="hourly forecast" 
+                data-hourly-forecast>
                     <h2 class="title-2">Today at</h2>
                     <div class="slider-container">
                         <ul class="slider-list" data-temp>


### PR DESCRIPTION
# Update to project

## Hourly Forecast CSS Explanation

### `.slider-container`
- The `.slider-container` class is applied to the container element of the hourly forecast slider.
- `overflow-x: auto;` is used to enable horizontal scrolling when content overflows the container's width.
- `margin-inline: -16px;` creates a negative horizontal margin to offset padding or margin on child elements, preventing extra space on the sides.

### Hiding WebKit Scrollbar
- To improve the design, the `-webkit-scrollbar` is hidden for a cleaner look in WebKit browsers (e.g., Chrome).

### `.slider-list`
- The `.slider-list` class selects the list of forecast items.
- `display: flex;` makes the list items display in a horizontal row.
- `gap: 12px;` adds 12px of space between each list item for better spacing.

### Adjusting the First List
- The `.slider-list:first-child` selector targets the first list within the container.
- `margin-block-end: 16px;` adds 16px of space below the first list, separating it from the rest of the content.

### Pseudo-Elements for List Separators
- `::before` and `::after` pseudo-elements are used to create horizontal dividers before and after each list item.
- `content: "";` ensures these pseudo-elements are generated.
- `min-width: 4px;` sets a minimum width of 4px to create visual separators between the list items.

### `.slider-item`
- The `.slider-item` class is applied to each forecast item.
- `min-width: 110px;` sets a minimum width of 110px for each item.
- `flex: 1 1 100%;` allows each item to expand and shrink as needed, ensuring they occupy available space efficiently.

These CSS rules enhance the layout and appearance of the hourly forecast section, providing a cleaner and well-organized design with appropriate spacing and separators between forecast items.

Thanks!